### PR TITLE
pkg: danctnix: qt6-base-es2: upgrade to 6.8.1

### DIFF
--- a/danctnix/qt6-base-es2/.SRCINFO
+++ b/danctnix/qt6-base-es2/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = qt6-base-es2
 	pkgdesc = A cross-platform application and UI framework
-	pkgver = 6.8.0
+	pkgver = 6.8.1
 	pkgrel = 1
 	url = https://www.qt.io
 	arch = x86_64
@@ -79,10 +79,10 @@ pkgbase = qt6-base-es2
 	optdepends = unixodbc: ODBC driver
 	provides = qt6-base
 	conflicts = qt6-base
-	source = git+https://code.qt.io/qt/qtbase#tag=v6.8.0
+	source = git+https://code.qt.io/qt/qtbase#tag=v6.8.1
 	source = qt6-base-cflags.patch
 	source = qt6-base-nostrip.patch
-	sha256sums = 3ec5b25b078190b46cb4ce83f7d8967649c0a786c4d2fddd65715e60c751cdc6
+	sha256sums = 1582d2a5953a0ba8499bf63ef873847dbbb7717b8e2e55207ad4206f877023c6
 	sha256sums = 5411edbe215c24b30448fac69bd0ba7c882f545e8cf05027b2b6e2227abc5e78
 	sha256sums = 4b93f6a79039e676a56f9d6990a324a64a36f143916065973ded89adc621e094
 

--- a/danctnix/qt6-base-es2/PKGBUILD
+++ b/danctnix/qt6-base-es2/PKGBUILD
@@ -9,8 +9,8 @@
 # DANCTNIX: Enable QT_FEATURE_opengles2
 
 pkgname=qt6-base-es2
-_pkgver=6.8.0
-pkgver=6.8.0
+_pkgver=6.8.1
+pkgver=6.8.1
 pkgrel=1
 arch=(x86_64 armv7h aarch64)
 url='https://www.qt.io'
@@ -89,7 +89,7 @@ _pkgfn=qtbase
 source=(git+https://code.qt.io/qt/$_pkgfn#tag=v$_pkgver
         qt6-base-cflags.patch
         qt6-base-nostrip.patch)
-sha256sums=('3ec5b25b078190b46cb4ce83f7d8967649c0a786c4d2fddd65715e60c751cdc6'
+sha256sums=('1582d2a5953a0ba8499bf63ef873847dbbb7717b8e2e55207ad4206f877023c6'
             '5411edbe215c24b30448fac69bd0ba7c882f545e8cf05027b2b6e2227abc5e78'
             '4b93f6a79039e676a56f9d6990a324a64a36f143916065973ded89adc621e094')
 


### PR DESCRIPTION
This fixes plasmashell (among others) failing to start for ppp users with this message : 
```plasmashell: symbol lookup error: /usr/lib/libQt6Qml.so.6: undefined symbol: _ZN23QPropertyBindingPrivate18notifyNonRecursiveERK15QVarLengthArrayI26QPropertyBindingPrivatePtrLx256EE, version Qt_6_PRIVATE_API```