### PR TITLE
pkg: danctnix: qt6-base-es2: fix overwritten `provides` array

### DIFF
--- a/danctnix/qt6-base-es2/.SRCINFO
+++ b/danctnix/qt6-base-es2/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = qt6-base-es2
 	pkgdesc = A cross-platform application and UI framework
 	pkgver = 6.8.2
-	pkgrel = 3
+	pkgrel = 4
 	url = https://www.qt.io
 	arch = x86_64
 	arch = armv7h
@@ -132,4 +132,5 @@ pkgname = qt6-base-es2
 	depends = zlib
 	depends = zstd
 	depends = qt6-translations
+	provides = qt6-base
 	provides = libQt6Core.so.6

--- a/danctnix/qt6-base-es2/PKGBUILD
+++ b/danctnix/qt6-base-es2/PKGBUILD
@@ -15,7 +15,7 @@
 pkgname=qt6-base-es2
 _pkgver=6.8.2
 pkgver=${_pkgver/-/}
-pkgrel=3
+pkgrel=4
 arch=(x86_64 armv7h aarch64)
 url='https://www.qt.io'
 license=(GPL3 LGPL3 FDL custom)
@@ -134,7 +134,7 @@ build() {
 package() {
   pkgdesc='A cross-platform application and UI framework'
   depends+=(qt6-translations)
-  provides=(libQt6Core.so.6)
+  provides+=(libQt6Core.so.6)
   DESTDIR="$pkgdir" cmake --install build
 
   install -Dm644 $_pkgfn/LICENSES/* -t "$pkgdir"/usr/share/licenses/$pkgbase


### PR DESCRIPTION
This fixes not being able to install or upgrade the package because it doesn't provide `qt6-base` but conflicts with it.