### PR TITLE
Phosh: Enable libphosh

### DIFF
--- a/phosh/phosh/PKGBUILD
+++ b/phosh/phosh/PKGBUILD
@@ -56,6 +56,7 @@ build() {
         -D gtk_doc=true
         -D man=true
         -D phoc_tests=disabled
+        -D bindings-lib=true
     )
     arch-meson $pkgname-$pkgver output "${meson_options[@]}"
     meson compile -C output


### PR DESCRIPTION
Enable libphosh so it can be used by other applications such as phrog