### PR TITLE
DRAFT: pkg: danctnix: megapixels2: initial attempt

### DIFF
--- a/danctnix/libdng/PKGBUILD
+++ b/danctnix/libdng/PKGBUILD
@@ -1,0 +1,20 @@
+# Maintainer: 1peter10 <peter@linmob.net>
+pkgname=libdng
+pkgver=0.2.1
+pkgrel=1
+pkgdesc="Interface library between libtiff and the world to make sure the output is valid DNG"
+url="https://gitlab.com/megapixels-org/libdng"
+license=('MIT')
+arch=('x86_64' 'armv7h' 'aarch64')
+makedepends=('cmake' 'linux-megi-headers' 'meson' 'scdoc' 'libtiff')
+source=("https://gitlab.com/megapixels-org/libdng/-/archive/${pkgver}/libdng-${pkgver}.tar.gz")
+sha512sums=('9a2bee7f4d33dd087bfdfe744319edcbfd22dbc420c506dcb978974cbc6724141fa6ecc2ff5c6c43419d4bb8054e9ed97550590259c325887ec93fef68e17a83')
+
+build() {
+    arch-meson $pkgname-$pkgver build
+    ninja -C build
+}
+
+package() {
+    DESTDIR="$pkgdir" ninja -C build install
+}

--- a/danctnix/libmegapixels/PKGBUILD
+++ b/danctnix/libmegapixels/PKGBUILD
@@ -1,0 +1,21 @@
+# Maintainer: 1peter10 <peter@linmob.net>
+pkgname=libmegapixels
+pkgver=0.2.2
+pkgrel=1
+pkgdesc="The device abstraction for the Megapixels application"
+url="https://gitlab.com/megapixels-org/libmegapixels"
+license=('GPL-3.0-or-later')
+arch=('x86_64' 'armv7h' 'aarch64')
+depends=('libconfig')
+makedepends=('meson' 'ninja' 'cmake')
+source=("https://gitlab.com/megapixels-org/libmegapixels/-/archive/${pkgver}/libmegapixels-${pkgver}.tar.gz")
+sha512sums=('af80989e0499cb3f6ba6c3dc599a08a2507659dc3abebf4834937c05cdbd8bd4ff0ba0d1568971753562a192853b06b5782843aec15d18577844e5e971b4e387')
+
+build() {
+    arch-meson ${pkgname}-$pkgver build
+    ninja -C build
+}
+
+package() {
+    DESTDIR="$pkgdir" ninja -C build install
+}

--- a/danctnix/megapixels2/90-megapixels.rules
+++ b/danctnix/megapixels2/90-megapixels.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="leds", ACTION=="add", KERNEL=="white:flash", \
+  RUN+="/bin/chmod 666 /sys/class/leds/%k/flash_strobe"

--- a/danctnix/megapixels2/PKGBUILD
+++ b/danctnix/megapixels2/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: 1peter10 <peter@linmob.net>
+pkgname=megapixels2
+_pkgname=Megapixels
+pkgver=2.0.0_alpha2
+_pkgver=2.0.0-alpha2
+pkgrel=1
+pkgdesc="The Linux-phone camera application - 2.0.0 alpha"
+url="https://gitlab.com/megapixels-org/Megapixels"
+license=('GPL-3.0-or-later')
+arch=('x86_64' 'armv7h' 'aarch64')
+depends=('feedbackd' 'glib2' 'gtk4' 'imagemagick' 'libdng' 'libepoxy' 'libjpeg-turbo' 'libraw' 'zbar')
+makedepends=('cmake' 'meson' 'ninja')
+optdepends=('postprocessd: additional postprocess config')
+replaces=('megaixels')
+source=("https://gitlab.com/megapixels-org/Megapixels/-/archive/${_pkgver}/Megapixels-${_pkgver}.tar.gz"
+        '90-megapixels.rules')
+sha512sums=('68894585dba3a38efd35c3c6200550384a40b26f1930c5b04480f751118f453f860374e3a210301218d07315854446b153b340203d365afbc53b9a5206fff924'
+	    'b8b70fb48fbdaf227936a5dcfb75637d8cd576c5c22a141d880c51746a6e53cc52544986e2908ccecdb29a0347b940003a3ebeeff371d6f748b0ceb4145a435c')
+
+build() {
+    arch-meson $_pkgname-$_pkgver build
+    ninja -C build
+}
+
+package() {
+    DESTDIR="$pkgdir" ninja -C build install
+
+    install -Dm644 "${srcdir}/90-megapixels.rules" -t "${pkgdir}/usr/lib/udev/rules.d/"
+}

--- a/danctnix/postprocessd/PKGBUILD
+++ b/danctnix/postprocessd/PKGBUILD
@@ -1,18 +1,19 @@
 # Maintainer: Danct12 <danct12@disroot.org>
 pkgname=postprocessd
-pkgver=0.3.0
-pkgrel=2
+pkgver=0.4.0_git20250630
+pkgrel=1
+_commit=d97a24ddfa58764a9d131a4b5ea790a86e35f51f
 pkgdesc="A native postprocessing pipeline for Megapixels"
 url="https://git.sr.ht/~martijnbraam/postprocessd"
 license=('GPL')
 arch=('x86_64' 'armv7h' 'aarch64')
-depends=('libraw' 'libtiff4' 'libjpeg-turbo' 'libexif' 'opencv')
+depends=('lensfun' 'libraw' 'libtiff4' 'libjpeg-turbo' 'libexif' 'opencv')
 makedepends=('scdoc' 'meson' 'ninja')
-source=("$pkgname-$pkgver.tar.gz::https://git.sr.ht/~martijnbraam/postprocessd/archive/$pkgver.tar.gz")
-sha256sums=('4fa41f0ebd0321d3abd51084b3546c97bef95f34ed0614c01d77250d9e5274c3')
+source=("$pkgname-$_commit.tar.gz::https://gitlab.com/megapixels-org/postprocessd/-/archive/$_commit/postprocessd-$_commit.tar.gz")
+sha512sums=('c241bce2139e6c61621700dcfdaef32a0d027f44fa2ef0bd9f4782a20c1db8f7881059f86c7da2454d0885322085d5c132c051cc9c49639bb5f4440e9b580948')
 
 build() {
-    arch-meson $pkgname-$pkgver build
+    arch-meson $pkgname-$_commit build
     ninja -C build
 }
 


### PR DESCRIPTION
It builds, but it also segfaults.
As other camera apps that work on Mobian and postmarketOS (snapshot) also do not seem to work at all, I assume a distribution level issue.